### PR TITLE
Add early return when header is missing

### DIFF
--- a/back-end/helpers/jwt-helpers.js
+++ b/back-end/helpers/jwt-helpers.js
@@ -8,7 +8,7 @@ function createJWT(id) {
 
 function getUserIdFromToken(req, res) {
   if (!req.headers["authorization"]) {
-    rejectAsUnauthorized(res)
+    return rejectAsUnauthorized(res);
   }
 
   const bearerHeader = req.headers["authorization"];


### PR DESCRIPTION
@mcmoonstruck - Added return if Authorization header is missing. With the current implementation, the next lines continue to run and will throw an error when it reaches `bearerHeader.split(" ");` because `bearerHeader` will be `undefined`.