### PR TITLE
Explictly state why users were recommended

### DIFF
--- a/front-end/src/components/Dashboard/index.js
+++ b/front-end/src/components/Dashboard/index.js
@@ -111,7 +111,7 @@ class Dashboard extends React.Component {
           <SideBarNav>
           </SideBarNav>
           <RightPanel>
-            {this.state.github_info && <Recommendations />}
+            {this.state.github_info && <Recommendations preferredLanguage={this.state.github_info.language} />}
             <DashboardContentContainer>
               <DashboardUserProfileImage>
                 {this.renderGitHubImage()}

--- a/front-end/src/shared/Recommendations.js
+++ b/front-end/src/shared/Recommendations.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { fetchRecommendedUsers } from '../api/RecommendationsApi';
 import { getUserIdFromJWT } from '../helpers/auth';
@@ -67,10 +68,15 @@ class Recommendations extends React.Component {
     return (
       <RecContainer>
         <RecHeader>Recommended Connections</RecHeader>
+        <RecSubHeader>Based on your preferred language: {this.props.preferredLanguage || 'No Preference'}</RecSubHeader>
         {this.state.isLoading ? <RecSpinner /> : this.renderRecommendedUsersList()}
       </RecContainer>
     );
   }
+}
+
+Recommendations.propTypes = {
+  preferredLanguage: PropTypes.string,
 }
 
 const RecSpinner = styled(LoadingSpinner)`
@@ -84,6 +90,11 @@ const RecNotification = styled.div`
 
 const RecHeader = styled.h1`
   margin: 0;
+`
+
+const RecSubHeader = styled.h2`
+  margin: 5px 0;
+  font-size: 1.2em;
 `
 
 const RecList = styled.ul`


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30938547/82520044-06727800-9ad8-11ea-8335-9afc42144297.png)

Per customer requirements, it is now explicitly stated in the Recommendations List why the set was recommended to the user.