### PR TITLE
Add connections database table

### DIFF
--- a/database/20200506_create-schema.sql
+++ b/database/20200506_create-schema.sql
@@ -14,3 +14,11 @@ CREATE TABLE github_info (
     profile_image_url VARCHAR(1000),
     language VARCHAR(255)
 );
+
+CREATE TABLE connections (
+    id SERIAL NOT NULL PRIMARY KEY,
+    user1_id INTEGER NOT NULL,
+    user2_id INTEGER NOT NULL,
+    recommendation_accepted BOOLEAN DEFAULT NULL,
+    connection_accepted BOOLEAN DEFAULT NULL
+);


### PR DESCRIPTION
This is a quick PR to add the `connections` table to the database, since this will be required for multiple stories... and I want to make sure no one is blocked. I have already added this table to the Heroku postgres DB instance.